### PR TITLE
add benchmarks

### DIFF
--- a/bench/riemann/codec_bench.clj
+++ b/bench/riemann/codec_bench.clj
@@ -1,0 +1,48 @@
+(ns riemann.codec-bench
+  (:require criterium.core
+            [riemann.codec :refer :all]
+            [clojure.test :refer :all])
+  (:import [riemann.codec Msg Event Query]))
+
+(defn msg
+  "Map to Msg"
+  [m]
+  (-> m
+    (assoc :events (map map->Event (:events m)))
+    (map->Msg)))
+
+(deftest protobufs-bench
+  (println "deserialize\n")
+  (let [m (msg {:events [{:host "a"
+                          :service "b"
+                          :state "c"
+                          :description "yo"
+                          :metric (float 1.8)
+                          :tags ["a" "b" "c"]
+                          :time 12345
+                          :ttl (float 10)}]})
+        serialized (encode-pb-msg m)]
+    (criterium.core/bench (decode-pb-msg serialized)))
+
+  (println "serialize\n")
+  (let [m (msg {:events [{:host "a"
+                          :service "b"
+                          :state "c"
+                          :description "yo"
+                          :metric (float 1.8)
+                          :tags ["a" "b" "c"]
+                          :time 12345
+                          :ttl (float 10)}]}) ]
+    (criterium.core/bench (encode-pb-msg m)))
+
+  (println "roundtrip\n")
+  (let [roundtrip (fn [m] (let [m' (-> m encode-pb-msg decode-pb-msg)]))
+        m (msg {:events [{:host "a"
+                          :service "b"
+                          :state "c"
+                          :description "yo"
+                          :metric (float 1.8)
+                          :tags ["a" "b" "c"]
+                          :time 12345
+                          :ttl (float 10)}]})]
+    (criterium.core/bench (roundtrip m))))

--- a/project.clj
+++ b/project.clj
@@ -6,4 +6,8 @@
   :dependencies [[org.clojure/tools.logging "0.2.3"]
                  [less-awful-ssl "1.0.0"]
                  [com.aphyr/riemann-java-client "0.3.1"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.6.0"]]}})
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.6.0"]]}
+             :bench {:dependencies [[org.clojure/clojure "1.6.0"]
+                                    [criterium "0.4.1"]]
+                     :jvm-opts ["-server" "-Xms1024m" "-Xmx1024m" "-XX:+UseParNewGC" "-XX:+UseConcMarkSweepGC" "-XX:+CMSParallelRemarkEnabled" "-XX:+AggressiveOpts" "-XX:+UseFastAccessorMethods" "-XX:+CMSClassUnloadingEnabled"]
+                     :test-paths ["bench"]}})

--- a/test/riemann/codec_test.clj
+++ b/test/riemann/codec_test.clj
@@ -87,6 +87,6 @@
                                    :tags ["a" "b" "c"]
                                    :time 12345
                                    :ttl (float 10)}]})]
-;             (time (dotimes [n 10000000]
-;                     (roundtrip m))))))
+             ;(time (dotimes [n 10000000]
+                     ;(roundtrip m))))))
              )))


### PR DESCRIPTION
just some basic criterium benches (if I'm right in understanding, this is the code riemann itself uses to decode events. Is that right?)

results:

```
lein test riemann.codec-bench
deserialize

WARNING: Final GC required 1.486769491876056 % of runtime
Evaluation count : 220086720 in 60 samples of 3668112 calls.
             Execution time mean : 269.709399 ns
    Execution time std-deviation : 9.968997 ns
   Execution time lower quantile : 248.817440 ns ( 2.5%)
   Execution time upper quantile : 288.583788 ns (97.5%)
                   Overhead used : 2.012488 ns
serialize

Evaluation count : 18958200 in 60 samples of 315970 calls.
             Execution time mean : 3.402603 µs
    Execution time std-deviation : 139.221146 ns
   Execution time lower quantile : 3.181787 µs ( 2.5%)
   Execution time upper quantile : 3.655199 µs (97.5%)
                   Overhead used : 2.012488 ns
roundtrip

Evaluation count : 16436280 in 60 samples of 273938 calls.
             Execution time mean : 3.887767 µs
    Execution time std-deviation : 349.777645 ns
   Execution time lower quantile : 3.457450 µs ( 2.5%)
   Execution time upper quantile : 4.755289 µs (97.5%)
                   Overhead used : 2.012488 ns

Found 4 outliers in 60 samples (6.6667 %)
        low-severe       3 (5.0000 %)
        low-mild         1 (1.6667 %)
 Variance from outliers : 65.2368 % Variance is severely inflated by outliers
```