### PR TITLE
Cache local host name.

### DIFF
--- a/src/riemann/codec.clj
+++ b/src/riemann/codec.clj
@@ -12,6 +12,8 @@
 
 (def event-keys (set (map keyword (Event/getBasis))))
 
+(def local-host-name (delay (.. InetAddress getLocalHost getHostName)))
+
 (defn assoc-default
   "Like assoc, but only alters the map if it does not already contain the given
   key.
@@ -92,7 +94,7 @@
   [e]
   (-> e
     (assoc-default :time (/ (System/currentTimeMillis) 1000))
-    (assoc-default :host (.. InetAddress getLocalHost getHostName))
+    (assoc-default :host @local-host-name)
     encode-pb-event))
 
 (defn decode-pb-msg


### PR DESCRIPTION
The rationale for this is that getting local host in some situations can be slow and
as a result degrades overall system performance. We hit this issue in Amazon VPC
which seems to be rate limiting internal DNS requests.