### PR TITLE
Remove nil custom attributes during serialization

### DIFF
--- a/src/riemann/codec.clj
+++ b/src/riemann/codec.clj
@@ -80,10 +80,11 @@
     (when (:time e)         (.setTime         event (long (:time e))))
     (when (:ttl e)          (.setTtl          event (:ttl e)))
     (doseq [k (clojure.set/difference (set (keys e)) event-keys)]
-      (let [a (Proto$Attribute/newBuilder)]
-        (.setKey a (name k))
-        (.setValue a (get e k))
-        (.addAttributes event a)))
+      (when-let [v (get e k)]
+        (let [a (Proto$Attribute/newBuilder)]
+          (.setKey a (name k))
+          (.setValue a v)
+          (.addAttributes event a))))
     (.build event)))
 
 (defn encode-client-pb-event


### PR DESCRIPTION
Hi Kyle,

I stumbled across this earlier today: My dashboard was unable to query the index because as it turned out, nearly every event contained a custom attribute with a `nil` value. 

Based on [this SO post](http://stackoverflow.com/questions/21227924/handling-null-values-in-protobuffers), it sounds like protobufs are not supposed to contain null values; removing those attributes seems like the right thing to do.

Thanks again for Riemann!