### PR TITLE
Support sending namespaced keys

### DIFF
--- a/src/riemann/codec.clj
+++ b/src/riemann/codec.clj
@@ -82,7 +82,7 @@
     (doseq [k (clojure.set/difference (set (keys e)) event-keys)]
       (when-let [v (get e k)]
         (let [a (Proto$Attribute/newBuilder)]
-          (.setKey a (name k))
+          (.setKey a (str (when (namespace k) (str (namespace k) \/)) (name k)))
           (.setValue a v)
           (.addAttributes event a))))
     (.build event)))

--- a/test/riemann/codec_test.clj
+++ b/test/riemann/codec_test.clj
@@ -80,7 +80,8 @@
                            :key1 "value1"
                            :key2 "value2"
                            :time 12345
-                           :ttl (float 10)}]})
+                           :ttl (float 10)
+                           :my-ns/key3 "value3"}]})
 
            (let [m (msg {:events [{:host "a"
                                    :service "b"


### PR DESCRIPTION
I noticed that when I use the Java client, I'm able to use custom attribute keys like "my-ns/my-key" and Riemann will correctly convert that to a namespaced key. 

It didn't work in the Clojure client, however... until now :)

Includes a corresponding addition to the unit tests.